### PR TITLE
Use proper aggregation before passing to message() for reference.test(verbose=TRUE) 

### DIFF
--- a/R/reference.test.R
+++ b/R/reference.test.R
@@ -75,7 +75,7 @@ reference.test <- function(expr, envir = parent.frame(),
                   ignore.row.order = ignore.row.order)
 
   if (verbose && !isTRUE(eq)) {
-    message(eq)
+    message(paste(eq, collapse = "\n"))
   }
 
   isTRUE(eq)


### PR DESCRIPTION
Encountered while debugging https://github.com/Rdatatable/data.table/issues/6671:

```
Modes: numeric, listLengths: 1, 4names for current but not for targetAttributes: < target is NULL, current is list >target is numeric, current is data.table
```

The `all.equal()` output will be a character vector if not `TRUE`, which `message()` will concatenate with `''` but which `print(all.equal(...))` will concatenate with `'\n'`. Matching `all.equal()`'s own print behavior will give more readable output.

PS thanks for your tests! It caught an error in the {data.table} dev version 👍 